### PR TITLE
Fix: Use jekyll-build-pages action for compatibility

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -36,26 +36,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1'
-          bundler-cache: true
-
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle install
-
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
 
       - name: Build with Jekyll
-        env:
-          JEKYLL_ENV: production
-        run: |
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_url }}"
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+          baseurl: "${{ steps.pages.outputs.base_url }}"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Correction du workflow pour utiliser l'action officielle jekyll-build-pages qui est optimisée pour GitHub Pages et évite les problèmes de version Ruby.